### PR TITLE
Feature: rotating long images

### DIFF
--- a/novels_dl/epub/writers/image_writer.py
+++ b/novels_dl/epub/writers/image_writer.py
@@ -30,6 +30,10 @@ class ImageWriter(Writer):
                         response = self.ctx.requests.get(image_src, stream=True)
                         image = Image.open(response.raw)
                         image = image.convert('RGB')  # prevents exception when image has transparency
+
+                        if self.ctx.epub_options.rotate_long_images and image.width > image.height:
+                            image = image.rotate(270, expand=True)
+
                         image.save(os.path.join(self.ctx.working_tempdir, "images", f"image-{image_counter}.jpeg"))
                         del response
                         del image

--- a/novels_dl/interface/cli/cli_entrypoint.py
+++ b/novels_dl/interface/cli/cli_entrypoint.py
@@ -5,7 +5,7 @@ from novels_dl.localization import get_localization
 from novels_dl.context import ContextManager
 from novels_dl.epub import EpubGenerator
 from novels_dl.interface.cli.steps import cli_authenticate, cli_get_output_path,\
-    cli_initialize_epub_options, cli_prefetch_novel, cli_volume_split
+    cli_initialize_epub_options, cli_prefetch_novel, cli_volume_split, cli_rotate_long_images
 
 
 def cli_entrypoint():
@@ -20,6 +20,7 @@ def cli_entrypoint():
             cli_prefetch_novel(context)
             cli_get_output_path(context)
             cli_initialize_epub_options(context)
+            cli_rotate_long_images(context)
 
             generator = EpubGenerator(context)
             if cli_volume_split(context):

--- a/novels_dl/interface/cli/steps/__init__.py
+++ b/novels_dl/interface/cli/steps/__init__.py
@@ -3,3 +3,4 @@ from novels_dl.interface.cli.steps.cli_authenticate import cli_authenticate
 from novels_dl.interface.cli.steps.cli_get_output_path import cli_get_output_path
 from novels_dl.interface.cli.steps.cli_initialize_epub_options import cli_initialize_epub_options
 from novels_dl.interface.cli.steps.cli_volume_split import cli_volume_split
+from novels_dl.interface.cli.steps.cli_rotate_long_images import cli_rotate_long_images

--- a/novels_dl/interface/cli/steps/cli_rotate_long_images.py
+++ b/novels_dl/interface/cli/steps/cli_rotate_long_images.py
@@ -1,0 +1,24 @@
+from colorama import Fore, Style
+from novels_dl.context import Context
+from novels_dl.localization import get_localization
+
+
+def cli_rotate_long_images(context: Context):
+    """Gets email + password from standard input and tries to authenticate."""
+
+    print(Style.BRIGHT + get_localization("CLI_ROTATE_LONG_ASK") + Style.RESET_ALL)
+    print(get_localization("CLI_ROTATE_LONG_EXPLANATION") + "\n")
+
+    choice = -1
+    while choice not in [1, 2]:
+        choice = input(Style.RESET_ALL + Style.BRIGHT + get_localization("UTIL_CHOOSE_1_2"))
+        choice = int(choice) if choice.isnumeric() else choice
+
+    print(Style.RESET_ALL)
+
+    if choice == 1:
+        context.epub_options.rotate_long_images = False
+    elif choice == 2:
+        context.epub_options.rotate_long_images = True
+
+

--- a/novels_dl/localization/localization_entries.py
+++ b/novels_dl/localization/localization_entries.py
@@ -93,7 +93,16 @@ localization_entries = {
                             "[2] Wygeneruj tyle plików .epub, ile jest tomów light novel",
         "CLI_VOL_SPLIT_WARN": "\nUwaga! Jeśli wybierzesz opcję 2, obraz okładki dla poszczególnych tomów się nie "
                               "zmieni.\nStrona novelki.pl nie udostępnia obrazów okładek dla poszczególnych tomów.\n"
-                              "Dla rozróżnienia, na każdą z okładek zostanie naniesiony prostokąt z numerem tomu.\n"
+                              "Dla rozróżnienia, na każdą z okładek zostanie naniesiony prostokąt z numerem tomu.\n",
+
+        "CLI_ROTATE_LONG_ASK": "Czy chcesz włączyć obracanie długich ilustracji?\n"
+                               "[1] Zostaw ilustracje bez zmian\n"
+                               "[2] Obracaj ilustracje\n",
+
+        "CLI_ROTATE_LONG_EXPLANATION": "Jeśli włączysz tę opcję, obrazki których szerokość jest większa niż wysokość\n"
+                                       "zostaną obrócone o 90 stopni, tak aby lepiej wykorzystywać ekran e-czytników.",
+
+        "UTIL_CHOOSE_1_2": "Wybierz 1 lub 2: "
     },
 
     "en": {
@@ -192,6 +201,14 @@ localization_entries = {
                              "[2] Generate as many .epub files as there are light novel volumes",
         "CLI_VOL_SPLIT_WARN": "\nWarning: if you select option 2, the cover image for individual volumes will not "
                               "change.\nThe novelki.pl website does not provide cover images for individual volumes.\n"
-                              "For differentiation, a rectangle with volume number will be drawn on each cover image.\n"
+                              "For differentiation, a rectangle with volume number will be drawn on each cover image.\n",
+
+        "CLI_ROTATE_LONG_ASK": "Do you want to enable rotation of long images?\n"
+                               "[1] Leave images unchanged\n"
+                               "[2] Rotate images\n",
+        "CLI_ROTATE_LONG_EXPLANATION": "If you enable this option, images which width is greater than the height\n"
+                                       "will be rotated by 90 degrees to make better use of the e-reader screen.",
+
+        "UTIL_CHOOSE_1_2": "Type 1 or 2: "
     }
 }

--- a/novels_dl/models/epub_options.py
+++ b/novels_dl/models/epub_options.py
@@ -4,13 +4,8 @@ from typing import Optional
 class EpubOptions:
     """Stores data about ebook formatting."""
 
-    cover_aspect_ratio: Optional[float] = None
-    """If set, this option will resize cover image to match the specified aspect ratio.
-    (NOT IMPLEMENTED YET)"""
-
     rotate_long_images: bool = False
-    """If set to True, long images will be rotated 90deg to be displayed vertically.
-    (NOT IMPLEMENTED YET)"""
+    """If set to True, long images will be rotated 90deg clockwise (to be displayed vertically on ebook readers)."""
 
     convert_quotes_to_hyphens: bool = False
     """If set to True, all English-styled novels will be converted to Polish style


### PR DESCRIPTION
Added option to rotate long images _(width > height)_.
Images are rotated 90deg clockwise.
This allows to make better use of ebook readers (which are usually vertical)